### PR TITLE
docs: fix misused command in quick setup guide

### DIFF
--- a/index.md
+++ b/index.md
@@ -68,7 +68,7 @@ A complete solution to package and build a ready for distribution Electron app f
       "dist": "electron-builder"
     }
     ```
-    Then you can run `yarn dist` (to package in a distributable format (e.g. dmg, windows installer, deb package)) or `yarn pack` (only generates the package directory without really packaging it. This is useful for testing purposes).
+    Then you can run `yarn dist` (to package in a distributable format (e.g. dmg, windows installer, deb package)) or `yarn run pack` (only generates the package directory without really packaging it. This is useful for testing purposes).
 
     To ensure your native dependencies always matched the electron version, simply add script `"postinstall": "electron-builder install-app-deps"` to your `package.json`.
 


### PR DESCRIPTION
Made same changes as #6056 in `docs` branch